### PR TITLE
Fixed TypeMismatch error related to settings field

### DIFF
--- a/adx_buyer_api/examples/v201109/basic_operations/add_campaign.rb
+++ b/adx_buyer_api/examples/v201109/basic_operations/add_campaign.rb
@@ -60,11 +60,11 @@ def add_campaign()
         :target_search_network => false,
         :target_content_network => true,
         :target_content_contextual => false
-      }
-      :settings => {
+      },
+      :settings => [{
         :xsi_type => 'RealTimeBiddingSetting',
         :opt_in => 'true'
-      }
+      }]
     }
   }
 


### PR DESCRIPTION
Fixed TypeMismatch: expected: 'Array' provided 'Hash' for field 'settings' - Passed an Array instead of a Hash for field RealtimeBiddingSetting
