### PR TITLE
Update to work with latest savon

### DIFF
--- a/ads_common/lib/ads_common/savon_service.rb
+++ b/ads_common/lib/ads_common/savon_service.rb
@@ -98,16 +98,16 @@ module AdsCommon
       original_action_name =
           get_service_registry.get_method_signature(action)[:original_name]
       original_action_name = action if original_action_name.nil?
-      response = @client.request(original_action_name) do |soap|
+      response = @client.request(original_action_name) do |soap, wsdl, http|
         soap.body = args
-        set_headers(soap, extra_namespaces)
+        set_headers(http, soap, extra_namespaces)
       end
       return response
     end
 
     # Executes each handler to generate SOAP headers.
-    def set_headers(soap, extra_namespaces)
-      header_handler.prepare_request(@client.http, soap)
+    def set_headers(http, soap, extra_namespaces)
+      header_handler.prepare_request(http, soap)
       soap.namespaces.merge!(extra_namespaces) unless extra_namespaces.nil?
     end
 


### PR DESCRIPTION
Savon was refactored to fix threadsafe issues. It dups httpi object (https://github.com/savonrb/savon/commit/77cb1adf56bb1d77042505d691938464a8e58034#L0R82) before invoking supplied block therefore `#set_headers` uses original httpi object which won't be used inside savon. My patch fixes `SavonService` to change appropriate httpi object.
