### PR TITLE
Fixed way to add label into link_to. It was creating the <a> element wro...

### DIFF
--- a/adwords_api/examples/adwords_on_rails/app/views/account/index.html.erb
+++ b/adwords_api/examples/adwords_on_rails/app/views/account/index.html.erb
@@ -7,7 +7,7 @@
 <% else %>
   <% @accounts.each_pair do |id, account| %>
   <li>
-    <%= link_to(:controller => 'account', :action => 'select', :account_id => account.customer_id) { account.customer_id.to_s } %>
+    <%= link_to(account.customer_id.to_s, :controller => 'account', :action => 'select', :account_id => account.customer_id) %>
     (<%= account.login %> / <%= account.company_name %> )
 
     <% unless account.child_accounts.empty? %>
@@ -15,7 +15,7 @@
       <% sorted_accounts = account.child_accounts.sort {|a, b| a.customer_id <=> b.customer_id} %>
       <% sorted_accounts.each do |account| %>
       <li>
-        <%= link_to(:controller => 'account', :action => 'select', :account_id => account.customer_id) { account.customer_id.to_s } %>
+        <%= link_to(account.customer_id.to_s, :controller => 'account', :action => 'select', :account_id => account.customer_id) %>
         (<%= account.login %> / <%= account.company_name %> )
       <% end %>
     </ul>


### PR DESCRIPTION
I noticed that the way link_to was being created was making the `<a>` to be created wrongly (there was no href attribute).

`<a account_id="8282277272" action="select" controller="account">8282277272</a>
        ( loginname / companyname )`

I added the label as the first argument of link_to and it is creating the `<a>` element correctly.
