### PR TITLE
Fix the auth type for oauth2_service_endpoint

### DIFF
--- a/ads_common/lib/ads_common/api.rb
+++ b/ads_common/lib/ads_common/api.rb
@@ -201,7 +201,7 @@ module AdsCommon
               @config,
               api_config.environment_config(environment, :oauth_scope)
           )
-        when :OAUTH2_SERVICE_ACCOUNT_
+        when :OAUTH2_SERVICE_ACCOUNT
           environment = @config.read('service.environment',
               api_config.default_environment())
           AdsCommon::Auth::OAuth2ServiceAccountHandler.new(


### PR DESCRIPTION
- The Auth Type is incorrect and should be same as specified in adwords_api, dfp_api etc.