### PR TITLE
Allow prompt parameter in oauth url

### DIFF
--- a/ads_common/lib/ads_common/auth/oauth2_handler.rb
+++ b/ads_common/lib/ads_common/auth/oauth2_handler.rb
@@ -211,7 +211,8 @@ module AdsCommon
           if verification_code.nil? || verification_code.empty?
             uri_options = {
               :access_type => credentials[:oauth2_access_type],
-              :approval_prompt => credentials[:oauth2_approval_prompt]
+              :approval_prompt => credentials[:oauth2_approval_prompt],
+              :prompt => credentials[:oauth2_prompt]
             }.reject {|k, v| v.nil?}
             oauth_url = client.authorization_uri(uri_options)
             raise AdsCommon::Errors::OAuth2VerificationRequired.new(oauth_url)

--- a/adwords_api/adwords_api.yml
+++ b/adwords_api/adwords_api.yml
@@ -17,6 +17,7 @@
   #:oauth2_state: INSERT_OAUTH2_STATE_HERE
   #:oauth2_access_type: INSERT_OAUTH2_ACCESS_TYPE_HERE
   #:oauth2_approval_prompt: INSERT_OAUTH2_APPROVAL_PROMPT_HERE
+  #:oauth2_prompt: INSERT_OAUTH2_PROMPT_HERE
   # You can define extra scopes so that you can reuse your refresh token for
   # other APIs.
   #:oauth2_extra_scopes: [INSERT_EXTRA_SCOPES_HERE]

--- a/adwords_api/examples/adwords_on_rails/config/adwords_api.yml
+++ b/adwords_api/examples/adwords_on_rails/config/adwords_api.yml
@@ -15,6 +15,7 @@
   #:oauth2_state: INSERT_OAUTH2_STATE_HERE
   #:oauth2_access_type: INSERT_OAUTH2_ACCESS_TYPE_HERE
   #:oauth2_approval_prompt: INSERT_OAUTH2_APPROVAL_PROMPT_HERE
+  #:oauth2_prompt: INSERT_OAUTH2_PROMPT_HERE
   # Callback is set up by the application at runtime.
   #:oauth2_callback: INSERT_OAUTH2_CALLBACK_URL_HERE
 


### PR DESCRIPTION
This change allows you to set the prompt parameter in OAuth URLs.

I wasn't sure what the "approval_prompt" parameter does and if that is different than what "prompt" is meant to be. For example, setting approval_prompt to "consent" does not seem to work, but setting prompt to consent will cause the allow offline access prompt to appear correctly. As such, this pull request could be reworked to remove/replace approval_prompt if it turned out that approval_prompt was meant to be prompt.
