### PR TITLE
Change signet to have loose constraint

### DIFF
--- a/ads_common/google-ads-common.gemspec
+++ b/ads_common/google-ads-common.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('google-ads-savon', '~> 1.0.1')
   s.add_runtime_dependency('httpi', '~> 2.3')
   s.add_runtime_dependency('httpclient', '~> 2.7')
-  s.add_runtime_dependency('signet', '~> 0.6.0')
+  s.add_runtime_dependency('signet', '~> 0.6')
   s.add_development_dependency('rake', '>= 10.4.2')
 end


### PR DESCRIPTION
'signet' gem is out of date.

It has gem conflicts when I put it and Google official gem 'googleauth' in same Gemfile.
'googleauth' lastest version has gem constraint 'signet' >= 0.7

People can't use this gem while they still want connect to other Google apis using Oauth2, like Google Analytics.

'googleauth' github repo url: https://github.com/google/google-auth-library-ruby