### PR TITLE
Fix create_creative_from_template Example

### DIFF
--- a/dfp_api/examples/v201608/creative_service/create_creative_from_template.rb
+++ b/dfp_api/examples/v201608/creative_service/create_creative_from_template.rb
@@ -63,9 +63,11 @@ def create_creative_from_template()
   asset_variable_value = {
       :xsi_type => 'AssetCreativeTemplateVariableValue',
       :unique_name => 'Imagefile',
-      :asset_byte_array => image_data_base64,
-      # Filenames must be unique.
-      :file_name => "image%d.jpg" % Time.new.to_i
+      :asset => {
+        :asset_byte_array => image_data_base64,
+        # Filenames must be unique.
+        :file_name => "image%d.jpg" % Time.new.to_i
+      }
   }
 
   # Create the image width variable value.

--- a/dfp_api/examples/v201611/creative_service/create_creative_from_template.rb
+++ b/dfp_api/examples/v201611/creative_service/create_creative_from_template.rb
@@ -63,9 +63,11 @@ def create_creative_from_template()
   asset_variable_value = {
       :xsi_type => 'AssetCreativeTemplateVariableValue',
       :unique_name => 'Imagefile',
-      :asset_byte_array => image_data_base64,
-      # Filenames must be unique.
-      :file_name => "image%d.jpg" % Time.new.to_i
+      :asset => {
+        :asset_byte_array => image_data_base64,
+        # Filenames must be unique.
+        :file_name => "image%d.jpg" % Time.new.to_i
+      }
   }
 
   # Create the image width variable value.

--- a/dfp_api/examples/v201702/creative_service/create_creative_from_template.rb
+++ b/dfp_api/examples/v201702/creative_service/create_creative_from_template.rb
@@ -63,9 +63,11 @@ def create_creative_from_template()
   asset_variable_value = {
       :xsi_type => 'AssetCreativeTemplateVariableValue',
       :unique_name => 'Imagefile',
-      :asset_byte_array => image_data_base64,
-      # Filenames must be unique.
-      :file_name => "image%d.jpg" % Time.new.to_i
+      :asset => {
+        :asset_byte_array => image_data_base64,
+        # Filenames must be unique.
+        :file_name => "image%d.jpg" % Time.new.to_i
+      }
   }
 
   # Create the image width variable value.


### PR DESCRIPTION
When I followed the example, I hit the error below.

```
AdsCommon::Errors::UnexpectedParametersError: [:asset_byte_array, :file_name] (AdsCommon::Errors::UnexpectedParametersError)
```