### PR TITLE
Change builder required version to 3.0 to support rails 3

### DIFF
--- a/ads_common/google-ads-common.gemspec
+++ b/ads_common/google-ads-common.gemspec
@@ -21,7 +21,7 @@ $:.unshift lib unless $:.include?(lib)
 require 'ads_common/version'
 
 Gem::Specification.new do |s|
-  s.name = 'google-ads-common'
+  s.name = 'reevoo-google-ads-common'
   s.version = AdsCommon::ApiConfig::CLIENT_LIB_VERSION
   s.summary = 'Common code for Google Ads APIs'
   s.description = 'Essential utilities shared by all Ads Ruby client libraries'
@@ -32,11 +32,11 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = '>= 2.0'
   s.required_rubygems_version = '>= 1.3.6'
-  s.rubyforge_project = 'google-ads-common'
+  s.rubyforge_project = 'reevoo-google-ads-common'
   s.require_path = 'lib'
   s.files = Dir.glob('{lib,test}/**/*') + %w(COPYING README.md ChangeLog)
   s.test_files = Dir.glob('test/test_*.rb')
-  s.add_runtime_dependency('google-ads-savon', '~> 1.0.2')
+  s.add_runtime_dependency('reevoo-google-ads-savon', '~> 1.0.2')
   s.add_runtime_dependency('httpi', '~> 2.3')
   s.add_runtime_dependency('httpclient', '~> 2.7')
   s.add_runtime_dependency('signet', '~> 0.7.0')

--- a/ads_savon/google-ads-savon.gemspec
+++ b/ads_savon/google-ads-savon.gemspec
@@ -5,7 +5,7 @@ $:.unshift lib unless $:.include? lib
 require "ads_savon/version"
 
 Gem::Specification.new do |s|
-  s.name        = "google-ads-savon"
+  s.name        = "reevoo-google-ads-savon"
   s.version     = GoogleAdsSavon::VERSION
   s.authors     = "Daniel Harrington"
   s.email       = "me@rubiii.com"
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "akami",    "~> 1.2"
   s.add_dependency "gyoku",    "~> 1.2"
 
-  s.add_dependency "builder",  "~> 3.2"
+  s.add_dependency "builder",  "~> 3.0"
   s.add_dependency "nokogiri", "~> 1.6"
 
   s.add_development_dependency "rake",    "~> 10.1"

--- a/adwords_api/google-adwords-api.gemspec
+++ b/adwords_api/google-adwords-api.gemspec
@@ -21,7 +21,7 @@ $:.unshift lib unless $:.include?(lib)
 require 'adwords_api/version'
 
 Gem::Specification.new do |s|
-  s.name = 'google-adwords-api'
+  s.name = 'reevoo-google-adwords-api'
   s.version = AdwordsApi::ApiConfig::CLIENT_LIB_VERSION
   s.summary = 'Ruby Client libraries for AdWords API'
   s.description = '%s is a AdWords API client library for Ruby' % s.name
@@ -32,12 +32,12 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = '>= 2.0'
   s.required_rubygems_version = '>= 1.3.6'
-  s.rubyforge_project = 'google-adwords-api'
+  s.rubyforge_project = 'reevoo-google-adwords-api'
   s.require_path = 'lib'
   s.files = Dir.glob('lib/**/*') +
       %w(COPYING README.md ChangeLog adwords_api.yml)
   s.test_files = ['test/suite_unittests.rb']
-  s.add_runtime_dependency('google-ads-common', '~> 0.14.1')
+  s.add_runtime_dependency('reevoo-google-ads-common', '~> 0.14.1')
   s.add_runtime_dependency('nori', '~> 2.6')
   s.add_development_dependency('rr', '~> 1.1.2')
   s.add_development_dependency('webmock', '~> 1.21.0')


### PR DESCRIPTION
- after upgrade of reevoo/adwords-api gem to use latest AdwordsAPI version (v201705) we found out that new version with updated dependencies is incompatible with Rails 3. That means it is impossible to install this gem to revieworld. To be more correct, there is a conflict in version of Builder gem used by action_pack (3.22.4) and by google-ads-savon (1.0.2). The action_pack requires builder in version 3.0.0 and google-ads-savon requires bulder in version 3.2.0.
- because google-ads-savon gem is dependency of google-ads-comon and this is dependency of google-adwords-api we need to fork all those gems, change theirs names and update dependencies to new gems.
- finaly we can change Builder gem version to ~> 3.0
- all those gems will be released on our private gems server http://gems