### PR TITLE
Support enumerations when generating types

### DIFF
--- a/ads_common/lib/ads_common/build/savon_registry.rb
+++ b/ads_common/lib/ads_common/build/savon_registry.rb
@@ -155,10 +155,11 @@ module AdsCommon
         return type
       end
 
-      # Extracts all possible enumerations for a type and adds them as a
+      # Extracts all possible enumerations for a type and adds them as an
       # `enumerations` key on the type.
       def extract_enumerations(type_element, type)
-        REXML::XPath.each(type_element, "restriction[@base='xsd:string']") do |enum_node|
+        REXML::XPath.each(type_element,
+            "restriction[@base='xsd:string']") do |enum_node|
           type.delete(:fields)
           type[:type] = enum_node.attribute('base').to_s.gsub(/^.+:/, '')
         end
@@ -166,7 +167,7 @@ module AdsCommon
           type[:enumerations] ||= []
           type[:enumerations] << enum_node.attribute('value').to_s
         end
-        return typetype
+        return type
       end
 
       # Extracts input parameters of given method as an array.

--- a/ads_common/lib/ads_common/build/savon_registry.rb
+++ b/ads_common/lib/ads_common/build/savon_registry.rb
@@ -160,8 +160,6 @@ module AdsCommon
         REXML::XPath.each(type_element, "restriction[@base='xsd:string']") do |seq_node|
           type.delete(:fields)
           type[:type] = seq_node.attribute('base').to_s.gsub(/^.+:/, '')
-          type[:min_occurs] = 0
-          type[:max_occurs] = 1
         end
         REXML::XPath.each(type_element, "restriction[@base='xsd:string']/enumeration") do |seq_node|
           type[:enumerations] ||= []

--- a/ads_common/lib/ads_common/build/savon_registry.rb
+++ b/ads_common/lib/ads_common/build/savon_registry.rb
@@ -146,26 +146,27 @@ module AdsCommon
           type[:fields] += get_element_fields(seq_node)
         end
 
-        try_extract_enumeration(type_element, type)
+        extract_enumerations(type_element, type)
 
         REXML::XPath.each(type_element, 'choice') do |seq_node|
           type[:choices] ||= []
           type[:choices] += get_element_fields(seq_node)
         end
-
-        type
+        return type
       end
 
-      def try_extract_enumeration(type_element, type)
-        REXML::XPath.each(type_element, "restriction[@base='xsd:string']") do |seq_node|
+      # Extracts all possible enumerations for a type and adds them as a
+      # `enumerations` key on the type.
+      def extract_enumerations(type_element, type)
+        REXML::XPath.each(type_element, "restriction[@base='xsd:string']") do |enum_node|
           type.delete(:fields)
-          type[:type] = seq_node.attribute('base').to_s.gsub(/^.+:/, '')
+          type[:type] = enum_node.attribute('base').to_s.gsub(/^.+:/, '')
         end
-        REXML::XPath.each(type_element, "restriction[@base='xsd:string']/enumeration") do |seq_node|
+        REXML::XPath.each(type_element, "restriction[@base='xsd:string']/enumeration") do |enum_node|
           type[:enumerations] ||= []
-          type[:enumerations] << seq_node.attribute('value').to_s
+          type[:enumerations] << enum_node.attribute('value').to_s
         end
-        type
+        return typetype
       end
 
       # Extracts input parameters of given method as an array.


### PR DESCRIPTION
I am currently working on a library which uses this gem extensively, and have ran across the need to have access to the possible values of an `ENUMERABLE` type. Before this patch, code-gen would generate a rather unhelpful type for enums. i.e.

```ruby
registry.get_type_signature('CampaignStatus') #=> { :fields=>[] }
```

After this PR it will look like this:

```ruby
registry.get_type_signature('CampaignStatus') #=> { :type => 'string', :enumerations => ['UNKNOWN' , 'ENABLED', 'PAUSED', 'REMOVED', :min_occurs => 0, :max_occurs => 1 }
```

I'm not entirely sure what the best way to expose this is, so this is my first attempt. I would love some feedback to make this better so we can get it merged!

Cheers,
Ian