### PR TITLE
Fix typo in not_equal_to method in the AWQL query where builder

### DIFF
--- a/adwords_api/lib/adwords_api/query_utils/where_builder.rb
+++ b/adwords_api/lib/adwords_api/query_utils/where_builder.rb
@@ -31,7 +31,7 @@ module AdwordsApi
     end
 
     def not_equal_to(value)
-      @awql = sprintf("%s != $s", @field, value)
+      @awql = sprintf("%s != %s", @field, value)
     end
 
     def greater_than(value)


### PR DESCRIPTION
The not_equal_to method in the AWQL query where builder has a $ where a % should be.  This breaks it, as instead of inserting the value in the AQWL string it inserts a literal $s.  Every other one - equal_to, greater_than etc. - is fine, just this one.

Fixed by literally changing one character, $ to %.