### PR TITLE
Fixes on pql_statement_utils to support Ruby < 2.4.0

### DIFF
--- a/ad_manager_api/lib/ad_manager_api/pql_statement_utils.rb
+++ b/ad_manager_api/lib/ad_manager_api/pql_statement_utils.rb
@@ -41,10 +41,11 @@ module AdManagerApi
 
   # Values class used by StatementBuilder.
   class PQLValues
+    INTEGER_KLASS = Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.0') ? Fixnum : Integer
+    
     VALUE_TYPES = {
       Numeric => 'NumberValue',
-      Fixnum => 'NumberValue',
-      Integer => 'NumberValue',
+      INTEGER_KLASS => 'NumberValue',
       Float => 'NumberValue',
       String => 'TextValue',
       TrueClass => 'BooleanValue',

--- a/ad_manager_api/lib/ad_manager_api/pql_statement_utils.rb
+++ b/ad_manager_api/lib/ad_manager_api/pql_statement_utils.rb
@@ -98,7 +98,7 @@ module AdManagerApi
       if dateTypes.include?(value.class)
         value = value.to_h
       end
-      return value if type.nil?
+      raise "Value type (#{value.class}) is not supported" if type.nil?
       return {:xsi_type => type, :value => value}
     end
   end

--- a/ad_manager_api/lib/ad_manager_api/pql_statement_utils.rb
+++ b/ad_manager_api/lib/ad_manager_api/pql_statement_utils.rb
@@ -43,6 +43,7 @@ module AdManagerApi
   class PQLValues
     VALUE_TYPES = {
       Numeric => 'NumberValue',
+      Fixnum => 'NumberValue',
       Integer => 'NumberValue',
       Float => 'NumberValue',
       String => 'TextValue',


### PR DESCRIPTION
Hi, every change is described in the commits, Fixnum is required in order to make ruby 2.1, 2.2, 2,3 to work, and the new error is need to avoid errors later when to_statement() is called.