### PR TITLE
Example fixed. Location extensions

### DIFF
--- a/adwords_api/examples/v201806/extensions/add_google_my_business_location_extensions.rb
+++ b/adwords_api/examples/v201806/extensions/add_google_my_business_location_extensions.rb
@@ -88,11 +88,11 @@ def add_gmb_location_extensions(gmb_email_address, gmb_access_token,
     :placeholder_types => [PLACEHOLDER_TYPE_LOCATION],
     :matching_function => {
       :operator => 'IDENTITY',
-      :lhs_operand => {
+      :lhs_operand => [{
         :xsi_type => 'ConstantOperand',
         :type => 'BOOLEAN',
         :boolean_value => true
-      }
+      }]
     }
   }
 

--- a/adwords_api/examples/v201809/extensions/add_google_my_business_location_extensions.rb
+++ b/adwords_api/examples/v201809/extensions/add_google_my_business_location_extensions.rb
@@ -88,11 +88,11 @@ def add_gmb_location_extensions(gmb_email_address, gmb_access_token,
     :placeholder_types => [PLACEHOLDER_TYPE_LOCATION],
     :matching_function => {
       :operator => 'IDENTITY',
-      :lhs_operand => {
+      :lhs_operand => [{
         :xsi_type => 'ConstantOperand',
         :type => 'BOOLEAN',
         :boolean_value => true
-      }
+      }]
     }
   }
 


### PR DESCRIPTION
While checking out the examples about location extension I noticed that it was throwing an error when associating a customer_feed, because:

```
AdsCommon::Errors::TypeMismatchError (AdsCommon::Errors::TypeMismatchError: expected: 'Array', provided: 'Hash' for field 'lhs_operand')
```