### PR TITLE
Fix NameError in example code

### DIFF
--- a/ad_manager_api/examples/v202105/native_style_service/get_all_native_styles.rb
+++ b/ad_manager_api/examples/v202105/native_style_service/get_all_native_styles.rb
@@ -46,7 +46,7 @@ def get_all_native_styles(ad_manager)
 
     # Increase the statement offset by the page size to get the next page.
     statement.offset += statement.limit
-  end while statement.offset < total_result_set_size
+  end while statement.offset < page[:total_result_set_size]
 
   puts 'Total number of native styles: %d' % page[:total_result_set_size]
 end

--- a/ad_manager_api/examples/v202105/proposal_service/get_all_proposals.rb
+++ b/ad_manager_api/examples/v202105/proposal_service/get_all_proposals.rb
@@ -43,7 +43,7 @@ def get_all_proposals(ad_manager)
 
     # Increase the statement offset by the page size to get the next page.
     statement.offset += statement.limit
-  end while statement.offset < total_result_set_size
+  end while statement.offset < page[:total_result_set_size]
 
   puts 'Total number of proposals: %d' % page[:total_result_set_size]
 end

--- a/ad_manager_api/examples/v202108/native_style_service/get_all_native_styles.rb
+++ b/ad_manager_api/examples/v202108/native_style_service/get_all_native_styles.rb
@@ -46,7 +46,7 @@ def get_all_native_styles(ad_manager)
 
     # Increase the statement offset by the page size to get the next page.
     statement.offset += statement.limit
-  end while statement.offset < total_result_set_size
+  end while statement.offset < page[:total_result_set_size]
 
   puts 'Total number of native styles: %d' % page[:total_result_set_size]
 end

--- a/ad_manager_api/examples/v202108/proposal_service/get_all_proposals.rb
+++ b/ad_manager_api/examples/v202108/proposal_service/get_all_proposals.rb
@@ -43,7 +43,7 @@ def get_all_proposals(ad_manager)
 
     # Increase the statement offset by the page size to get the next page.
     statement.offset += statement.limit
-  end while statement.offset < total_result_set_size
+  end while statement.offset < page[:total_result_set_size]
 
   puts 'Total number of proposals: %d' % page[:total_result_set_size]
 end

--- a/ad_manager_api/examples/v202111/native_style_service/get_all_native_styles.rb
+++ b/ad_manager_api/examples/v202111/native_style_service/get_all_native_styles.rb
@@ -46,7 +46,7 @@ def get_all_native_styles(ad_manager)
 
     # Increase the statement offset by the page size to get the next page.
     statement.offset += statement.limit
-  end while statement.offset < total_result_set_size
+  end while statement.offset < page[:total_result_set_size]
 
   puts 'Total number of native styles: %d' % page[:total_result_set_size]
 end

--- a/ad_manager_api/examples/v202111/proposal_service/get_all_proposals.rb
+++ b/ad_manager_api/examples/v202111/proposal_service/get_all_proposals.rb
@@ -43,7 +43,7 @@ def get_all_proposals(ad_manager)
 
     # Increase the statement offset by the page size to get the next page.
     statement.offset += statement.limit
-  end while statement.offset < total_result_set_size
+  end while statement.offset < page[:total_result_set_size]
 
   puts 'Total number of proposals: %d' % page[:total_result_set_size]
 end


### PR DESCRIPTION
When executing `ad_manager_api/examples/v202111/native_style_service/get_all_native_styles.rb`, the following error occurred.

~~~
undefined local variable or method `total_result_set_size' for #<GoogleAdmanager::Sandbox::CreativeService:0x00007f5f1b4d7d68> (NameError)
~~~

There was a small typo in the code, so I fixed it.