### PR TITLE
Fixed token refresh process to use proxy

### DIFF
--- a/ads_common/lib/ads_common/auth/oauth2_handler.rb
+++ b/ads_common/lib/ads_common/auth/oauth2_handler.rb
@@ -100,7 +100,9 @@ module AdsCommon
           if @client.issued_at.is_a?(String)
             @client.issued_at = Time.parse(@client.issued_at)
           end
-          @client.refresh!
+          proxy = @config.read('connection.proxy')
+          connection = (proxy.nil?) ? nil : Faraday.new(:proxy => proxy)
+          @client.refresh!(:connection => connection)
         rescue Signet::AuthorizationError => e
           raise AdsCommon::Errors::AuthError.new("OAuth2 token refresh failed",
               e, (e.response.nil?) ? nil : e.response.body)


### PR DESCRIPTION
This is a machine translation. I'm sorry if it's hard to understand.

### background

I used a proxy to authenticate with the Google Ad Manager API.

`ad_manager_api.yml`
~~~yml
:connection:
  :enable_gzip: false
  :proxy: http://user:password@proxy_hostname:8080
~~~

I was able to communicate with the API through the proxy, **but after an hour or so, the API stopped responding to me.**

~~~
/usr/local/bundle/gems/socksify-1.7.1/lib/socksify.rb:178:in `initialize': execution expired (Faraday::ConnectionFailed)
/usr/local/bundle/gems/socksify-1.7.1/lib/socksify.rb:178:in `initialize': execution expired (Net::OpenTimeout)
~~~

Due to the fact that the expiration time was one hour (`:expires_in: 3599`) , I assumed that the refresh process had failed.

I checked the code. I noticed that `fetch_access_token!`uses a proxy, but `refresh!` does not.

https://github.com/googleads/google-api-ads-ruby/blob/bac3587a0c9570f5f002fee829b488d631306711/ads_common/lib/ads_common/auth/oauth2_handler.rb#L227

https://github.com/googleads/google-api-ads-ruby/blob/bac3587a0c9570f5f002fee829b488d631306711/ads_common/lib/ads_common/auth/oauth2_handler.rb#L103

I made a patch to use proxy in `refresh!` as well, and now I can communicate with the API.

If there is another way to solve this problem, I would appreciate it if you could let me know. Thank you.