### PR TITLE
Final Release for adwords API with deprecation message

### DIFF
--- a/adwords_api/COPYING
+++ b/adwords_api/COPYING
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2010 Google Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/adwords_api/ChangeLog
+++ b/adwords_api/ChangeLog
@@ -1,0 +1,338 @@
+1.6.0:
+  - Adwords API has been sunset. This library is no longer maintained.
+  - Please upgrade to the Google Ads API: https://developers.google.com/google-ads/api/docs/client-libs/ruby
+
+1.5.0:
+  - Remove deprecated API version v201806.
+  - Fixed a release script issue that prevented older versions from being
+  removed. This change actually removes examples and support for v201710 and
+  v201802 of the AdWords API.
+
+1.4.0:
+  - Remove deprecated API version v201802.
+
+1.3.1:
+  - Support and examples for v201809.
+
+1.3.0:
+  - Remove deprecated API version v201710.
+  - Minor fix to paging through landscape pages using ServiceQuery.
+
+1.2.1:
+  - Support and examples for v201806.
+
+1.2.0:
+  - Remove deprecated API versions v201705 and v201708.
+
+1.1.1:
+  - Support and examples for v201802.
+
+1.1.0:
+  - Added ReportQueryBuilder and ServiceQueryBuilder to aid in constructing
+    AWQL for both contexts.
+  - Remove deprecated API version v201702.
+
+1.0.1:
+  - Support and examples for v201710.
+
+1.0.0:
+  - Major version bump. The library has been stable and feature complete for
+    some time, and this is more accurately reflected by this version number.
+  - Remove deprecated API version v201609.
+  - No longer include test files in the built gem.
+  - Fixed potential issue where ReportStream could not split sometimes when a
+    unicode character was returned across separate batches.
+  - Removing support for multiple environments.
+  - Require google-ads-common 1.0.0 or later from now on.
+
+0.25.1:
+  - Support and examples for v201708.
+
+0.25.0:
+  - Removed deprecated API version v201607.
+  - Require google-ads-common 0.14.1 or later from now on.
+
+0.24.1:
+  - Support and examples for v201705.
+  - Require google-ads-common 0.14.0 or later from now on for logging updates.
+
+0.24.0:
+  - Removed deprecated API version v201605.
+  - Require google-ads-common 0.13.0 or later from now on. This removes
+    support for p12 key files for service accounts.
+  - Fixing issue with report_stream handling of streams ending in newline.
+  - Fixed issue #107. Improved error messaging when trying to specify
+    unrecognized fields in report definition.
+
+0.23.1:
+  - Support and examples for v201702.
+
+0.23.0:
+  - Removed examples and tests from bundled gem. For code examples, see:
+    https://github.com/googleads/google-api-ads-ruby/tree/master/adwords_api/examples
+
+0.22.0:
+  - Removed deprecated API version v201603.
+
+0.21.1:
+  - Support and examples for v201609.
+  - Added logging of reporting HTTP response headers on DEBUG level.
+  - Added support for extension setting services in batch_job_utils.
+
+0.21.0:
+  - Removed deprecated API version v201601.
+  - Disallowed user agents with non-ASCII characters.
+
+0.20.1:
+  - Support and examples for v201607.
+  - Fixed issue #91 related to BJS utilities handling special characters.
+
+0.20.0:
+  - Started enforcing minumum Ruby runtime version via gemspec.
+  - Removed deprecated API version v201509.
+
+0.19.1:
+  - Support and examples for v201605.
+  - Require google-ads-common 0.12.3 or later from now on to support JSON
+    keyfiles for service accounts.
+
+0.19.0:
+  - Require google-ads-common 0.12.0 or later from now on. This also means
+    that Ruby 2.0 or later is required. Ruby 2.1 or later is recommended.
+  - Removed deprecated API version v201506.
+
+0.18.3:
+  - Support and examples for v201603.
+  - The include_zero_impressions field is no longer settable on a report
+    definition hash directly. Updated utilities and examples to set
+    corresponding HTTP level header instead.
+
+0.18.2:
+  - Require google-ads-common 0.11.3 or later from now on.
+  - Added support for custom user agent strings to include utility usage.
+
+0.18.1:
+  - Support and examples for v201601.
+  - Updated batch_job_utils to handle API changes in v201601.
+  - Require google-ads-common 0.11.2 or later from now on.
+
+0.18.0:
+  - Removed deprecated API version v201502.
+  - Support for streaming report requests in report_utils.
+  - Require google-ads-common 0.11.1 or later from now on.
+  - Updated batch_job_utils to support incremental uploads.
+  - Changed interface of batch_job_utils to avoid requiring users to manually
+    manage SOAP XML.
+
+0.17.0:
+  - Support and examples for v201509.
+  - Require google-ads-common 0.11.0 or later from now on.
+  - Updating report_utils for new version of nori in ads_common.
+
+0.16.1:
+  - General file cleanup.
+  - Improved errors handling (based on GitHub pull request).
+
+0.16.0:
+  - Removed deprecated API version v201409.
+  - Changed OAUTH2 JWT references to OAUTH2 Service Account.
+  - Require google-ads-common 0.10.0 or later from now on.
+  - Allowing report headers to be defined as booleans (this restores previous
+    behavior).
+
+0.15.2:
+  - Support and examples for v201506.
+  - Added support for including zero impression rows in reports via HTTP header.
+
+0.15.1:
+  - Allowing requests without CID specified for use with CustomerService.
+
+0.15.0:
+  - Removed deprecated API version v201406.
+  - Updated Feeds migration example to account for platform restrictions.
+  - Added support for skipping column header option in reporting.
+  - Reworked add sitelinks example for final URLs and functionString.
+
+0.14.2:
+  - Support and examples for v201502.
+  - Added support for skipping report header and summary options.
+
+0.14.1:
+  - Corrected the comments and settings regarding target_all in add_ad_groups
+    examples.
+  - Added new example for migrating to Upgraded URLs.
+  - Updated examples to reference final URLs.
+
+0.14.0:
+  - Removed deprecated API version v201402.
+  - Removed support for returnMoneyInMicros header.
+  - Reworked Places examples to reference Google My Business.
+
+0.13.4:
+  - Added rule-based remarketing example.
+  - Require google-ads-common 0.9.6 or later from now on.
+
+0.13.3:
+  - Fixing file permissions on gem.
+
+0.13.2:
+  - Support and examples for v201409.
+
+0.13.1:
+  - Added example for Ad Customizers.
+  - Removed support for ClientLogin (no longer supported by the API).
+
+0.13.0:
+  - Removed deprecated API version v201309.
+
+0.12.1:
+  - Support and examples for v201406.
+  - Changed default OAuth scope. See:
+    https://developers.google.com/adwords/api/docs/guides/authentication#scope
+
+0.12.0:
+  - Removed deprecated API version v201306.
+
+0.11.1:
+  - Support and examples for v201402.
+  - Removed support for ClientLogin for versions > v201309.
+
+0.11.0:
+  - Removed deprecated API version v201302.
+
+0.10.0:
+  - Support and examples for v201309.
+  - Removed deprecated API version v201209.
+
+0.9.3:
+  - Updated examples to use OAuth2 by default.
+  - Require google-ads-common 0.9.3 or later from now on.
+  - Support and examples for v201306.
+
+0.9.2:
+  - AdWords for Video API v201302 support and examples (beta feature).
+
+0.9.1:
+  - Support and examples for AdGroupBidModifierService.
+
+0.9.0:
+  - Shared set support and examples (beta feature).
+  - Updated feed services auto-generated code.
+  - AdWords for Video API support and examples (beta feature).
+  - Removed deprecated API version v201206.
+
+0.8.2:
+  - Support and examples for v201302.
+
+0.8.1:
+  - Examples for enhanced campaigns.
+  - Require google-ads-common 0.9.2 or later from now on.
+
+0.8.0:
+  - Removed deprecated API versions v201109, v201109_1.
+  - Removed support for deprecated Sandbox, see http://goo.gl/Plu3o
+  - Require google-ads-common 0.9.0 or later from now on.
+  - Added support for AOuth2.0 JWT, removed OAuth1.0a support.
+
+0.7.2:
+  - Fixed issue #87 specific to ruby1.8.
+
+0.7.1:
+  - Support and examples for v201209.
+
+0.7.0:
+  - MapEntry structures are returned as Hashes now (#26).
+  - Require google-ads-common 0.8.0 or later from now on.
+
+0.6.3:
+  - Support and examples for v201206.
+
+0.6.2:
+  - Require google-ads-common 0.7.3 or later from now on.
+  - Support for OAuth2 authentication method.
+
+0.6.1:
+  - Require google-ads-common 0.7.1 or later from now on.
+  - Updated User-Agent to a single standard.
+
+0.6.0:
+  - Added support for API v201109_1.
+  - Require google-ads-common 0.7.0 or later from now on.
+  - ReportUtil now logs request details on DEBUG level.
+  - Added support for v201109 BudgetOrderService.
+  - Removed outdated extensions.
+
+0.5.3:
+  - Fixed issue #70 (stricter client id validation).
+  - Now require Savon-0.9.9 (fixes Content-Length bug).
+
+0.5.2:
+  - Rework on examples.
+  - Tests for all examples.
+
+0.5.1:
+  - Require google-ads-common 0.6.3 or later from now on.
+  - Support for CAPTCHA challenge handling.
+  - Added .gemspec and updated packaging process.
+  - Removed explicit require for RubyGems, see README.
+  - Fixed reports retrieval via curb HTTPI backend.
+  - Removed support for deprecated BulkOpportunityService.
+
+0.5.0:
+  - Removed deprecated API versions (pre-v201109).
+  - Example updates and revamp.
+
+0.4.5:
+  - Support for GZip compression.
+  - Support for returnMoneyInMicros header.
+  - Require google-ads-common 0.6.1 or later from now on.
+
+0.4.4:
+  - Support for CreateAccountService.
+  - Require google-ads-common 0.6.0 or later from now on.
+  - Better input parameter validation and error reporting.
+
+0.4.3:
+  - Added example for client-side cross-client reporting.
+
+0.4.2:
+  - Updated Reporting error codes handling.
+  - Fix for old v13 services compatibility.
+  - Require google-ads-common 0.5.4 or later from now on.
+
+0.4.1:
+  - Support for v201109.
+  - Added support and example for AdHoc reports.
+  - Removed deprecated TrafficEstimatorService (v13 only).
+  - Support for proxies.
+  - Units spent count and other headers information can now be obtained by
+    passing user block to a method call.
+  - Require google-ads-common 0.5.2 or later from now on.
+
+0.4.0:
+  - First experimental Savon-based release.
+  - use_ruby_names is now deprecated and always true.
+
+0.2.1:
+  - Changes for future OAuth support.
+  - Require google-ads-common 0.5.0 or later from now on.
+
+0.2.0:
+  - Better support for UTF reports in download extensions.
+  - Require google-ads-common 0.4.0 or later from now on.
+  - Consolidated log output to single Logger, see README.
+
+0.1.2:
+  - Support for cross-client MCC reports.
+  - Documented library use for DoubleClick Ad Exchange Buyer API.
+  - Require google-ads-common 0.2.1 or later from now on.
+
+0.1.1:
+  - Added support for BulkOpportunityService and CampaignTargetService.
+  - Added examples for the above services.
+  - Bugfix: pointed gem to the correct Google Code project.
+  - Bugfix: correctly handle some API exceptions.
+  - Bugfix: remove non-existent method in extensions.
+
+0.1.0:
+  - First release.

--- a/adwords_api/LICENSE
+++ b/adwords_api/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2010 Google Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/adwords_api/README.md
+++ b/adwords_api/README.md
@@ -1,0 +1,39 @@
+# Google AdWords Client Library
+
+The AdWords API is no longer available. This library is no longer maintained.
+
+Please upgrade to the
+[Google Ads API](https://developers.google.com/google-ads/api/docs/start).
+
+To access the Google Ads API use the
+[google-ads-googleads](https://rubygems.org/gems/google-ads-googleads) library.
+
+# Copyright/License Info
+
+## Licence
+
+Copyright 2010-2017, Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at:
+
+> [http://www.apache.org/licenses/LICENSE-2.0]()
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Authors
+
+Authors:
+
+- Sérgio Gomes
+- Danial Klimkin
+- Michael Cloonan
+
+Maintainer:
+
+- Michael Cloonan

--- a/adwords_api/Rakefile
+++ b/adwords_api/Rakefile
@@ -1,0 +1,30 @@
+# Encoding: utf-8
+#
+# Copyright:: Copyright 2012, Google Inc. All Rights Reserved.
+#
+# License:: Licensed under the Apache License, Version 2.0 (the "License");
+#           you may not use this file except in compliance with the License.
+#           You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#           Unless required by applicable law or agreed to in writing, software
+#           distributed under the License is distributed on an "AS IS" BASIS,
+#           WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#           implied.
+#           See the License for the specific language governing permissions and
+#           limitations under the License.
+#
+# AdWords API Rakefile.
+
+lib = File.expand_path("../lib/", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+desc "Default target - generate and build."
+task default: %i[build]
+
+desc "Package the AdWords API library into a gem file."
+task :build do
+  result = system("/usr/bin/env gem build google-adwords-api.gemspec")
+  raise "Build failed." unless result
+end

--- a/adwords_api/THIS_BRANCH.MD
+++ b/adwords_api/THIS_BRANCH.MD
@@ -1,0 +1,5 @@
+# This branch
+
+This branch contains the final empty release of the AdWords API client library
+to update the message and package on Ruby Gems:
+https://rubygems.org/gems/google-adwords-api

--- a/adwords_api/google-adwords-api.gemspec
+++ b/adwords_api/google-adwords-api.gemspec
@@ -1,0 +1,41 @@
+# Encoding: utf-8
+#
+# Copyright:: Copyright 2012, Google Inc. All Rights Reserved.
+#
+# License:: Licensed under the Apache License, Version 2.0 (the "License");
+#           you may not use this file except in compliance with the License.
+#           You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#           Unless required by applicable law or agreed to in writing, software
+#           distributed under the License is distributed on an "AS IS" BASIS,
+#           WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#           implied.
+#           See the License for the specific language governing permissions and
+#           limitations under the License.
+
+lib = File.expand_path("../lib/", __FILE__)
+$:.unshift lib unless $:.include?(lib)
+
+Gem::Specification.new do |s|
+  s.name = "google-adwords-api"
+  s.version = "1.6.0"
+  s.summary = "Ruby Client libraries for AdWords API"
+  s.description =
+    "The AdWords API is no longer available. Please upgrade to the Google Ads API gem: google-ads-googleads"
+  s.homepage = "https://github.com/googleads/google-api-ads-ruby"
+  s.authors = ["Danial Klimkin", "Michael Cloonan"]
+  s.email = ["adwordsapiadvisor+michael@google.com"]
+  s.license = "Apache-2.0"
+  s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = ">= 2.0"
+  s.required_rubygems_version = ">= 1.3.6"
+  s.rubyforge_project = "google-adwords-api"
+  s.require_path = "lib"
+  s.files = Dir.glob("lib/**/*") + %w[COPYING README.md ChangeLog]
+  s.add_runtime_dependency("google-ads-common", "~> 1.0.0")
+  s.add_runtime_dependency("nori", "~> 2.6")
+  s.add_development_dependency("rr", "~> 1.1.2")
+  s.add_development_dependency("webmock", "~> 1.21")
+end

--- a/adwords_api/lib/adwords_api.rb
+++ b/adwords_api/lib/adwords_api.rb
@@ -1,0 +1,5 @@
+# Main namespace for all the client library's modules and classes.
+module AdwordsApi
+  puts "The AdWords API is no longer available.\nUse the Google Ads API instead:
+  https://developers.google.com/google-ads/api/docs/client-libs/ruby"
+end


### PR DESCRIPTION
This is just to keep a record of the final empty release of the adwords gem. Version 1.6.0

We don't want to merge this.