### PR TITLE
Set nokogiri dependency to 1.6 for google-ads-common

### DIFF
--- a/ads_common/google-ads-common.gemspec
+++ b/ads_common/google-ads-common.gemspec
@@ -41,8 +41,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('httpi', '~> 2.3')
   s.add_runtime_dependency('httpclient', '~> 2.7')
   s.add_runtime_dependency('signet', '~> 0.7')
-
-  s.add_dependency("nokogiri", "~> 1.6")
+  s.add_runtime_dependency('nokogiri', '~> 1.6')
 
   s.add_development_dependency('rake', '>= 12.3.3', '< 13.0')
   s.add_development_dependency('test-unit', '~> 3.2')

--- a/ads_common/google-ads-common.gemspec
+++ b/ads_common/google-ads-common.gemspec
@@ -35,12 +35,15 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'google-ads-common'
   s.require_path = 'lib'
   s.files = Dir.glob('lib/**/*') + %w(README.md ChangeLog)
+
   s.add_runtime_dependency('faraday', '>= 0.9', '< 2.0')
   s.add_runtime_dependency('google-ads-savon', '~> 1.0', '>=1.0.2')
   s.add_runtime_dependency('httpi', '~> 2.3')
   s.add_runtime_dependency('httpclient', '~> 2.7')
   s.add_runtime_dependency('signet', '~> 0.7')
-  s.add_runtime_dependency('nokogiri', '~> 1.12.5')
+
+  s.add_dependency("nokogiri", "~> 1.6")
+
   s.add_development_dependency('rake', '>= 12.3.3', '< 13.0')
   s.add_development_dependency('test-unit', '~> 3.2')
   s.add_development_dependency('webmock', '~> 3.0')


### PR DESCRIPTION
Upgrade fails because of dependency on nokogiri version (1.12.5)

Follow up from [comment](https://github.com/googleads/google-api-ads-ruby/commit/d75a1744845f21b3360c01f3f98a09493bb8ba55#r139405807)

We should not depend on such an old nokogiri version. 
Also it has to be consistent with version used in [ads-savon](https://github.com/googleads/google-api-ads-ruby/blob/main/ads_savon/google-ads-savon.gemspec#L26).
