### PR TITLE
Remove upper dependency for faraday

### DIFF
--- a/ads_common/google-ads-common.gemspec
+++ b/ads_common/google-ads-common.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'google-ads-common'
   s.require_path = 'lib'
   s.files = Dir.glob('lib/**/*') + %w(README.md ChangeLog)
-  s.add_runtime_dependency('faraday', '>= 0.9', '< 2.0')
+  s.add_runtime_dependency('faraday', '>= 0.9')
   s.add_runtime_dependency('google-ads-savon', '~> 1.0', '>=1.0.2')
   s.add_runtime_dependency('httpi', '~> 2.3')
   s.add_runtime_dependency('httpclient', '~> 2.7')

--- a/ads_common/google-ads-common.gemspec
+++ b/ads_common/google-ads-common.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'google-ads-common'
   s.require_path = 'lib'
   s.files = Dir.glob('lib/**/*') + %w(README.md ChangeLog)
-  s.add_runtime_dependency('faraday', '>= 0.9')
+  s.add_runtime_dependency('faraday', '>= 0.9', '< 2.9')
   s.add_runtime_dependency('google-ads-savon', '~> 1.0', '>=1.0.2')
   s.add_runtime_dependency('httpi', '~> 2.3')
   s.add_runtime_dependency('httpclient', '~> 2.7')


### PR DESCRIPTION
Faraday is used to pass to Signet::OAuth2::Client instance.
https://github.com/googleads/google-api-ads-ruby/blob/main/ads_common/lib/ads_common/auth/oauth2_handler.rb#L104

Signet does not depend Faraday 1.x, so we can remove the upper dependency in this gem.
https://github.com/googleapis/signet/blob/main/signet.gemspec#L23