### PR TITLE
Pass timezone object to Time constructor

### DIFF
--- a/ad_manager_api/lib/ad_manager_api/ad_manager_api_datetime.rb
+++ b/ad_manager_api/lib/ad_manager_api/ad_manager_api_datetime.rb
@@ -116,17 +116,16 @@ module AdManagerApi
         end
       else
         datetime_args = args
+        datetime_args = [0, 1, 1, 0, 0, 0] + args if args.length == 1
       end
       # Check the validity of the timezone parameter, which is required.
       if not TZInfo::Timezone.all_identifiers.include?(datetime_args.last)
         raise "Last argument to AdManagerDateTime constructor must be valid" +
             "timezone"
       end
-      # Set timezone attribute and pass its utc offset into the Time
-      # constructor.
+      # Set timezone attribute and pass it into the Time constructor.
       @timezone = TZInfo::Timezone.get(datetime_args.pop)
-      @time = Time.new(*datetime_args,
-          utc_offset=@timezone.current_period.utc_offset)
+      @time = Time.new(*datetime_args, @timezone)
     end
 
     # Create an AdManagerDateTime for the current time in the specified
@@ -175,7 +174,7 @@ module AdManagerApi
     # Convert AdManagerDateTime into a native ruby Time object.
     def to_time
       return Time.new(@time.year, @time.month, @time.day, @time.hour, @time.min,
-                      @time.sec, @timezone.current_period.utc_offset)
+                      @time.sec, @timezone)
     end
 
     # When an unrecognized method is applied to AdManagerDateTime, pass it

--- a/ad_manager_api/test/ad_manager_api/test_ad_manager_datetime.rb
+++ b/ad_manager_api/test/ad_manager_api/test_ad_manager_datetime.rb
@@ -210,18 +210,18 @@ class TestAdManagerApi < Test::Unit::TestCase
     hour_delta = 1  # Between 0 and 17
     day_delta = 3  # Between 0 and 6
     datetime = @ad_manager.datetime(
-        2017, 11, 7, 17, 30, 10, 'America/New_York'
+        2017, 10, 7, 17, 30, 10, 'America/New_York'
     )
     datetime = datetime - sec_delta - min_delta * 60 - hour_delta * 60 * 60 -
         day_delta * 60 * 60 * 24
     assert_equal(2017, datetime.year)
-    assert_equal(11, datetime.month)
+    assert_equal(10, datetime.month)
     assert_equal(7 - day_delta, datetime.day)
     assert_equal(17 - hour_delta, datetime.hour)
     assert_equal(30 - min_delta, datetime.min)
     assert_equal(10 - sec_delta, datetime.sec)
     assert_equal('America/New_York', datetime.timezone.identifier)
-    assert_equal(-18000, datetime.utc_offset)
+    assert_equal(-14400, datetime.utc_offset)
     assert_true(datetime.is_a? AdManagerApi::AdManagerDateTime)
   end
 


### PR DESCRIPTION
Fixes #205.

I'm very uncomfortable with the behavior required to make tests that call @api.utc() pass. I don't know what that functionality supports and was afraid to change them to call `utc()` with proper arguments.